### PR TITLE
fhirversion not capitalized

### DIFF
--- a/core/package-list.json
+++ b/core/package-list.json
@@ -17,7 +17,7 @@
              "path" : "http://hl7belgium.org/fhir/core/2020Jun",
              "status" : "ballot",
              "date" : "2020-06-15",
-             "fhirVersion" : "4.0.1",
+             "fhirversion" : "4.0.1",
              "sequence" : 1,
              "current" : true
             }

--- a/source/package-list.json
+++ b/source/package-list.json
@@ -17,7 +17,7 @@
              "path" : "http://hl7belgium.org/fhir/core/2020Jun",
              "status" : "ballot",
              "date" : "2020-06-15",
-             "fhirVersion" : "4.0.1",
+             "fhirversion" : "4.0.1",
              "sequence" : 1,
              "current" : true
             }


### PR DESCRIPTION
in package-list fhirVersion cannot camel case:
https://confluence.hl7.org/display/FHIR/FHIR+IG+PackageList+doco 

if it is camelCase an exception is thrown:

```
Problem with /Users/oliveregger/Documents/github/test-ig-publication/core/./2020Jun/package.tgz: missing url
Problem with /Users/oliveregger/Documents/github/test-ig-publication/core/./2020Jun/package.tgz: fhirVersions value mismatch (expected null, found 4.0.1
java.lang.NullPointerException
```